### PR TITLE
Replace pkg_resources usage and update CI for Python 3.13

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -10,9 +10,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest"]
+        exclude:
+          - python-version: "3.6"
+            os: "ubuntu-latest"
+          - python-version: "3.7"
+            os: "ubuntu-latest"
         include:
+          - python-version: "3.6"
+            os: "ubuntu-20.04"
+          - python-version: "3.7"
+            os: "ubuntu-22.04"
           - python-version: "3.13"
             os: "macos-latest"
           - python-version: "3.13"

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -19,7 +19,7 @@ jobs:
             os: "ubuntu-latest"
         include:
           - python-version: "3.6"
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
           - python-version: "3.7"
             os: "ubuntu-22.04"
           - python-version: "3.13"

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,29 +2,34 @@ name: Test
 on: 
   push:
     branches: [ main ]
+  pull_request:
+  workflow_dispatch:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.6","3.7", "3.8", "3.9"]
+        python-version: ["3.6","3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest"]
         include:
-          - python-version: "3.8"
+          - python-version: "3.13"
             os: "macos-latest"
-          - python-version: "3.8"
+          - python-version: "3.13"
             os: "windows-latest"
         
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: python -m pip install -U pip
+        run: |
+          python -m pip install -U pip
+          python -m pip install -r requirements.txt
+          python -m pip install .
       - name: Run tests
         run: |
-          pip install -r requirements.txt
           python -m unittest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -10,16 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest"]
         exclude:
-          - python-version: "3.6"
-            os: "ubuntu-latest"
           - python-version: "3.7"
             os: "ubuntu-latest"
         include:
-          - python-version: "3.6"
-            os: "ubuntu-22.04"
           - python-version: "3.7"
             os: "ubuntu-22.04"
           - python-version: "3.13"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,11 +13,14 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-from pkg_resources import DistributionNotFound,get_distribution
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:  # Python < 3.8
+    from importlib_metadata import PackageNotFoundError, version
 
 try:
-    __version__ = get_distribution("tweezepy").version
-except DistributionNotFound:
+    __version__ = version("tweezepy")
+except PackageNotFoundError:
     __version__ = "unknown version"
 
 # -- Project information -----------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "autograd",
+    "importlib_metadata; python_version < '3.8'",
     "numpy>=1.15",
     "scipy"
 ]

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,11 +1,23 @@
 import os
 import numpy as np
 import unittest
+from functools import wraps
 
 from tweezepy import AV, PSD
+import matplotlib.pyplot as plt
 
-from matplotlib.testing.decorators import cleanup
 this_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def cleanup(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        finally:
+            plt.close('all')
+
+    return wrapper
 
 class test_calibration(object):
     def setUp(self):

--- a/tweezepy/__init__.py
+++ b/tweezepy/__init__.py
@@ -5,21 +5,16 @@ from .simulations import simulate_trace
 from .simulations import downsampled_trace
 
 
-import os
-
-from pkg_resources import DistributionNotFound,get_distribution
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:  # Python < 3.8
+    from importlib_metadata import PackageNotFoundError, version
 
 try:
-    __version__ = get_distribution("tweezepy").version
-except DistributionNotFound:
+    __version__ = version("tweezepy")
+except PackageNotFoundError:
     __version__ = "unknown version"
 
-#this_directory = os.path.abspath(os.path.dirname(__file__))
-#pkginfo_path = os.path.join(this_directory,
-#                            'tweezepy_info.json')
-#pkginfo = json.load(open(pkginfo_path))
-
-#__version__ = pkginfo["version"]
 __all__ = [
            "AV",
            "PSD",

--- a/tweezepy/smmcalibration.py
+++ b/tweezepy/smmcalibration.py
@@ -16,7 +16,8 @@ Author: Ian L. Morgan
 email: ilmorgan@ucsb.edu
 """
 import numpy as np
-import pkg_resources
+import io
+import pkgutil
 
 from scipy.signal import welch
 from tweezepy.allanvar import avar, totvar
@@ -33,8 +34,10 @@ def load_trajectory():
     data : array-like
         Bead trajectory data in nm
     """
-    fname = pkg_resources.resource_stream(__name__, 'data/trajectory.csv')
-    data = np.loadtxt(fname, delimiter=',')
+    raw_data = pkgutil.get_data("tweezepy", "data/trajectory.csv")
+    if raw_data is None:
+        raise FileNotFoundError("Could not load tweezepy data/trajectory.csv")
+    data = np.loadtxt(io.StringIO(raw_data.decode("utf-8")), delimiter=',')
     return data
 
 


### PR DESCRIPTION
## Summary

Tweezepy currently depends on `pkg_resources` in both `__init__.py` and `smmcalibration.py`. This causes problems on Python 3.13+, where `pkg_resources` is no longer available in newer setuptools releases. This PR replaces those usages with `importlib.metadata` and `pkgutil.get_data`, and updates CI accordingly.

## Changes

- replace `pkg_resources` version lookups with `importlib.metadata`
- add `importlib_metadata` as a fallback dependency for Python < 3.8
- replace `pkg_resources.resource_stream` with `pkgutil.get_data` for bundled trajectory data loading
- add a local matplotlib cleanup wrapper in tests
- update the GitHub Actions workflow:
  - run on pull requests and manual dispatch
  - expand coverage to Python 3.7-3.13
  - remove Python 3.6 from the matrix
  - upgrade GitHub Action versions
  - install the package before running tests
  - add macOS and Windows coverage for the newest Python version

## Why

`pkg_resources` is no longer available in newer setuptools releases, which makes installation difficult with Python 3.13+ in this project context. See: https://setuptools.pypa.io/en/stable/history.html#v82-0-0

The CI updates extend coverage through Python 3.13 and remove Python 3.6, which is no longer supported by GitHub Actions.

## Notes

If you want any changes just let me know.